### PR TITLE
    Update Sguil output plugin (spo_sguil.c) to pull ip information from the event data if a packet does not exist for the event

### DIFF
--- a/src/output-plugins/spo_sguil.c
+++ b/src/output-plugins/spo_sguil.c
@@ -411,7 +411,9 @@ void Sguil(Packet *p, void *event, uint32_t event_type, void *arg)
     {
         /* ack! an event without a packet. Append IP data from event struct and append
         26 fillers */
-        if ( event_type == UNIFIED2_IDS_EVENT_VLAN){
+        if ( (event_type == UNIFIED2_IDS_EVENT_VLAN)||
+                (event_type == UNIFIED2_IDS_EVENT_MPLS) ||
+                (event_type == UNIFIED2_IDS_EVENT_VLAN)){
             SguilAppendIPHdrDataEVT(&list, event);
             int i;
             for(i = 0; i < 26; ++i)


### PR DESCRIPTION
... event data if a packet does not exist for the event
