### PR TITLE
Minor bugfix and improvement

### DIFF
--- a/src/barnyard2.h
+++ b/src/barnyard2.h
@@ -63,7 +63,7 @@
 #define VER_MAJOR		"2"
 #define VER_MINOR		"1"
 #define VER_REVISION	"10"
-#define VER_BUILD		"310"
+#define VER_BUILD		"313"
 
 #define STD_BUF  1024
 

--- a/src/output-plugins/spo_alert_arubaaction.c
+++ b/src/output-plugins/spo_alert_arubaaction.c
@@ -274,12 +274,7 @@ void AlertArubaAction(Packet *p, void *event, uint32_t event_type, void *arg)
 	}
 
 	snprintf(cmdbufp, xmllenrem, "<ipaddr>%s</ipaddr>",
-#ifdef SUP_IP6
-			inet_ntoa(GET_SRC_ADDR(p))
-#else
-			inet_ntoa(p->iph->ip_src)
-#endif
-        );
+			inet_ntoa(GET_SRC_ADDR(p)));
 
 	xmllenrem -= strlen(cmdbufp);
 	cmdbufp += strlen(cmdbufp);

--- a/src/output-plugins/spo_alert_bro.c
+++ b/src/output-plugins/spo_alert_bro.c
@@ -51,6 +51,7 @@
 #include "plugbase.h"
 #include "unified2.h"
 #include "util.h"
+#include "ipv6_port.h"
 
 extern OptTreeNode *otn_tmp;
 

--- a/src/output-plugins/spo_alert_cef.c
+++ b/src/output-plugins/spo_alert_cef.c
@@ -68,6 +68,7 @@
 #include "plugbase.h"
 #include "unified2.h"
 #include "util.h"
+#include "ipv6_port.h"
 
 typedef struct _CEFData
 {

--- a/src/output-plugins/spo_alert_csv.c
+++ b/src/output-plugins/spo_alert_csv.c
@@ -66,6 +66,7 @@
 
 #include "sfutil/sf_textlog.h"
 #include "log_text.h"
+#include "ipv6_port.h"
 
 #define DEFAULT_CSV "timestamp,sig_generator,sig_id,sig_rev,msg,proto,src,srcport,dst,dstport,ethsrc,ethdst,ethlen,tcpflags,tcpseq,tcpack,tcpln,tcpwindow,ttl,tos,id,dgmlen,iplen,icmptype,icmpcode,icmpid,icmpseq"
 

--- a/src/output-plugins/spo_alert_fast.c
+++ b/src/output-plugins/spo_alert_fast.c
@@ -68,6 +68,8 @@
 
 #include "sfutil/sf_textlog.h"
 #include "log_text.h"
+#include "ipv6_port.h"
+
 
 /* full buf was chosen to allow printing max size packets
  * in hex/ascii mode:

--- a/src/output-plugins/spo_alert_fwsam.c
+++ b/src/output-plugins/spo_alert_fwsam.c
@@ -1047,16 +1047,16 @@ void AlertFWsam(Packet *p, void *event, uint32_t event_type, void *arg)
         for(i=0; i<FWSAM_REPET_BLOCKS && len; i++)
         {
             if( ( ( optp->how==FWSAM_HOW_THIS ) ?   /* if blocking mode SERVICE, check for src and dst    */
-                    ( lastbsip[i]==GET_SRC_IP(p) && lastbdip[i]==GET_DST_IP(p) && lastbproto[i]==GET_IPH_PROTO(p) &&
-                      ( IP_HAS_PORTS(p) ? /* check port only of TCP or UDP */
+		  ( lastbsip[i]==(unsigned long)GET_SRC_IP(p) && lastbdip[i]==(unsigned long)GET_DST_IP(p) && lastbproto[i]==GET_IPH_PROTO(p) &&
+		    ( IP_HAS_PORTS(p) ? /* check port only of TCP or UDP */
 /*                  ((optp->who==FWSAM_WHO_SRC)?(lastbsp[i]==record->sp):(lastbdp[i]==record->dp)):TRUE) ): */
                         lastbdp[i]==p->dp : TRUE
                       )
                     ) :
                     (
                       ( optp->who==FWSAM_WHO_SRC) ?
-                        ( lastbsip[i]==GET_SRC_IP(p) ) :
-                        ( lastbdip[i]==GET_DST_IP(p) )
+		      ( lastbsip[i]==(unsigned long)GET_SRC_IP(p) ) :
+		      ( lastbdip[i]==(unsigned long)GET_DST_IP(p) )
                     )
                  ) && /* otherwise if we block source, only compare source. Same for dest. */
                  lastbduration[i]==optp->duration &&
@@ -1073,8 +1073,8 @@ void AlertFWsam(Packet *p, void *event, uint32_t event_type, void *arg)
             if(++lastbpointer>=FWSAM_REPET_BLOCKS)      /* increase repetitive check pointer */
                 lastbpointer=0;
 
-            lastbsip[lastbpointer]=GET_SRC_IP(p);     /* and note packet details */
-            lastbdip[lastbpointer]=GET_DST_IP(p);
+            lastbsip[lastbpointer]=(unsigned long)GET_SRC_IP(p);     /* and note packet details */
+            lastbdip[lastbpointer]=(unsigned long)GET_DST_IP(p);
             lastbduration[lastbpointer]=optp->duration;
             lastbmode[lastbpointer]=optp->how|optp->who|optp->loglevel;
             lastbproto[lastbpointer]=GET_IPH_PROTO(p);
@@ -1169,8 +1169,8 @@ void AlertFWsam(Packet *p, void *event, uint32_t event_type, void *arg)
                         LogMessage("DEBUG => [Alert_FWsam] Src IP     :  %s\n",sfip_ntoa(GET_SRC_IP(p)));
                         LogMessage("DEBUG => [Alert_FWsam] Dest IP    :  %s\n",sfip_ntoa(GET_DST_IP(p)));
 #else
-                        LogMessage("DEBUG => [Alert_FWsam] Src IP     :  %s\n",inet_ntoa(p->iph->ip_src));
-                        LogMessage("DEBUG => [Alert_FWsam] Dest IP    :  %s\n",inet_ntoa(p->iph->ip_dst));
+                        LogMessage("DEBUG => [Alert_FWsam] Src IP     :  %s\n",inet_ntoa(GET_SRC_ADDR(p)));
+                        LogMessage("DEBUG => [Alert_FWsam] Dest IP    :  %s\n",inet_ntoa(GET_DST_ADDR(p)));
 #endif
                         LogMessage("DEBUG => [Alert_FWsam] Src Port   :  %i\n",p->sp);
                         LogMessage("DEBUG => [Alert_FWsam] Dest Port  :  %i\n",p->dp);

--- a/src/output-plugins/spo_alert_prelude.c
+++ b/src/output-plugins/spo_alert_prelude.c
@@ -46,8 +46,8 @@
 #include "mstring.h"
 #include "map.h"
 #include "unified2.h"
-
 #include "barnyard2.h"
+#include "ipv6_port.h"
 
 #define ANALYZER_CLASS "NIDS"
 #define ANALYZER_MODEL "Snort"

--- a/src/output-plugins/spo_alert_syslog.c
+++ b/src/output-plugins/spo_alert_syslog.c
@@ -68,6 +68,8 @@
 #include "plugbase.h"
 #include "unified2.h"
 #include "util.h"
+#include "ipv6_port.h"
+
 
 typedef struct _SyslogData
 {

--- a/src/output-plugins/spo_alert_test.c
+++ b/src/output-plugins/spo_alert_test.c
@@ -87,6 +87,7 @@
 #include "util.h"
 
 #include "spo_alert_test.h"
+#include "ipv6_port.h"
 
 #define TEST_FLAG_FILE     0x01
 #define TEST_FLAG_STDOUT   0x02

--- a/src/output-plugins/spo_log_ascii.c
+++ b/src/output-plugins/spo_log_ascii.c
@@ -68,6 +68,7 @@
 #include "plugbase.h"
 #include "unified2.h"
 #include "util.h"
+#include "ipv6_port.h"
 
 /* internal functions */
 void LogAsciiInit(char *args);

--- a/src/output-plugins/spo_syslog_full.h
+++ b/src/output-plugins/spo_syslog_full.h
@@ -42,6 +42,14 @@
 #include "strlcpyu.h"
 #include "unified2.h"
 
+
+#define OUT_MODE_DEFAULT 0
+#define OUT_MODE_FULL 1
+
+#define LOG_UDP 0
+#define LOG_TCP 1
+
+
 typedef struct _OpSyslog_Data 
 {
     char *server;


### PR DESCRIPTION
Bumped revision to 313

Fix: Enable compilation without error with --enable-ipv6

Fix to spo_syslog_full
Fix: operation_mode parsing (strcasecmp return value)
Fix: defined values (literals instead of 0 and 1) for clarity.
Fix: in complete mode used a } instead of a ] at one place in a output
literal.
Fix: Check for input data in spo_database.c where revision is 0, we do
not log and we print messages
Modified: Replaced WARNING database by INFO database so people are less
alarmed when those pop-up.
