### PR TITLE
Fix staged installs - use DESTDIR.

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -4,4 +4,8 @@ AUTOMAKE_OPTIONS=foreign no-dependencies
 EXTRA_DIST = barnyard2.conf 
 
 install-data-am:
-	test -e $(sysconfdir)/barnyard2.conf || install -m 600 $(top_srcdir)/etc/barnyard2.conf $(sysconfdir)
+	test -e $(DESTDIR)$(sysconfdir) || \
+		$(mkinstalldirs) $(DESTDIR)$(sysconfdir)
+	test -e $(DESTDIR)$(sysconfdir)/barnyard2.conf || \
+		$(INSTALL_DATA) -m 600 $(top_srcdir)/etc/barnyard2.conf \
+		$(DESTDIR)$(sysconfdir)/barnyard2.conf


### PR DESCRIPTION
Just fixes "make DESTDIR=/tmp/staging install".
