### PR TITLE
Added target directory creation for configuration file.

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -4,4 +4,5 @@ AUTOMAKE_OPTIONS=foreign no-dependencies
 EXTRA_DIST = barnyard2.conf 
 
 install-data-am:
-	test -e $(sysconfdir)/barnyard2.conf || install -m 600 $(top_srcdir)/etc/barnyard2.conf $(sysconfdir)
+	test -d $(sysconfdir) || install -m 755 -d $(sysconfdir)
+	test -e $(sysconfdir)/barnyard2.conf || install -m 600 $(top_srcdir)/etc/barnyard2.conf $(sysconfdir)/barnyard2.conf


### PR DESCRIPTION
The installation process of the barnyard2.conf configuration file assumes that
the target directory exists. This breaks 'make install' calls for prefixes
which do not exist at the time of installation, resulting in a destination
file name of 'etc'. We therefore explicitly create the destination
folder now.

Signed-off-by: Thorsten Fischer thorsten@froschi.org
