### PR TITLE
Changing spo_alert_fwsam to be an alert output plugin

### DIFF
--- a/src/output-plugins/spo_alert_fwsam.c
+++ b/src/output-plugins/spo_alert_fwsam.c
@@ -593,7 +593,7 @@ void AlertFWsamInit(char *args)
 #endif
 
     /* Set the preprocessor function into the function list */
-    AddFuncToOutputList(AlertFWsam, OUTPUT_TYPE__LOG, fwsamlist);
+    AddFuncToOutputList(AlertFWsam, OUTPUT_TYPE__ALERT, fwsamlist);
     AddFuncToCleanExitList(AlertFWsamCleanExitFunc, fwsamlist);
     AddFuncToRestartList(AlertFWsamRestartFunc, fwsamlist);
 }


### PR DESCRIPTION
The Snortsam output plugin is supposed to be an alert output plugin (spo_alert_fwsam), but in the output list configuration it's been set as a log output plugin. This fix follows the idea proposed on issue #26. 
