### PR TITLE
Make it possible to remove processed files

### DIFF
--- a/src/barnyard2.c
+++ b/src/barnyard2.c
@@ -491,7 +491,7 @@ static int ShowUsage(char *program_name)
     FPUTS_BOTH ("        -?         Show this information\n");
     FPUTS_BOTH ("\n");
     FPUTS_BOTH ("Continual Processing Options:\n");
-    FPUTS_UNIX ("        -a <dir>   Archive processed files to <dir>\n");
+    FPUTS_UNIX ("        -a <dir>   Archive processed files to <dir>, or remove if <dir> is empty\n");
     FPUTS_BOTH ("        -f <base>  Use <base> as the base filename pattern\n");
     FPUTS_BOTH ("        -d <dir>   Spool files from <dir>\n");
     FPUTS_BOTH ("        -n         Only process new events\n");

--- a/src/spooler.c
+++ b/src/spooler.c
@@ -380,6 +380,7 @@ int ProcessContinuous(const char *dirpath, const char *filebase,
     int                 waiting_logged = 0;
     uint32_t            skipped = 0;
     uint32_t            extension = 0;
+    char                *archive_dir;
 
     u_int32_t waldo_timestamp = 0;
     waldo_timestamp = timestamp; /* fix possible bug by keeping invocated timestamp at the time of the initial call */
@@ -400,6 +401,8 @@ int ProcessContinuous(const char *dirpath, const char *filebase,
 
         timestamp = extension;
     }
+
+    archive_dir = BcArchiveDir();
 
     /* Start the main process loop */
     while (exit_signal == 0)
@@ -486,9 +489,7 @@ int ProcessContinuous(const char *dirpath, const char *filebase,
                             spooler->state, spooler->filepath);
 
 #ifndef WIN32
-                /* archive the spool file */
-                if (BcArchiveDir() != NULL)
-                    ArchiveFile(spooler->filepath, BcArchiveDir());
+                ArchiveFile(spooler->filepath, archive_dir);
 #endif
 
                 /* we've finished with the spooler so destroy and cleanup */
@@ -563,9 +564,7 @@ int ProcessContinuous(const char *dirpath, const char *filebase,
                         break;
                 }
 
-                /* archive the file */
-                if (BcArchiveDir() != NULL)
-                    ArchiveFile(spooler->filepath, BcArchiveDir());
+                ArchiveFile(spooler->filepath, archive_dir);
 
                 /* close (ie. destroy and cleanup) the spooler so we can rotate */
                 spoolerClose(spooler);

--- a/src/util.c
+++ b/src/util.c
@@ -1798,12 +1798,29 @@ int Move(const char *source, const char *dest)
     return 0;
 }
 
-int ArchiveFile(const char *filepath, const char *archive_dir)
+/****************************************************************************
+ *
+ * Function: ArchiveFile(const char *filepath, const char *archive_dir)
+ *
+ * Purpose: Move a processed file to the specified directory after processing.
+ *
+ * Arguments: const char *filepath - The file to move or delete
+ *            const char *archive_dir - The destination directory. If empty
+ *                                      file will be removed
+ *
+ ***************************************************************************/
+void ArchiveFile(const char *filepath, const char *archive_dir)
 {
     char *dest;
     size_t dest_len;
     if(!filepath || !archive_dir)
-        return -1;  /* Invalid argument */
+        return;  /* Invalid argument */
+
+    /* just remove the file if an empty string is given */
+    if (archive_dir[0] == '\0') {
+        unlink(filepath);
+        return;
+    }
 
     /* Archive the file */
     dest_len = strlen(archive_dir) + 1 + strlen(strrchr(filepath, '/') + 1);
@@ -1813,7 +1830,6 @@ int ArchiveFile(const char *filepath, const char *archive_dir)
 
     Move(filepath, dest);
     free(dest);
-    return 0;
 }
 
 /****************************************************************************

--- a/src/util.h
+++ b/src/util.h
@@ -210,7 +210,7 @@ char *StripPrefixDir(char *prefix, char *dir);
 
 void TimeStats(void);
 
-int ArchiveFile(const char *, const char *);
+void ArchiveFile(const char *, const char *);
 
 char *GetUniqueName(char *);
 char *GetIP(char *);


### PR DESCRIPTION
Up to now it was not possible to simply remove processed files without
moving them elsewhere. Add this possibility by treating the empty string
as a special value to the -a option. (Such value would have little sense
anyway). So using -a "" makes barnyard directly remove the file without
trying to move it to another directory.
While at it, rework the ArchiveFile() function to not return anything,
since its return value it's unused.
