### PR TITLE
Fix: little issue when starting in SIDv2 mode, mainly due to a early

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -461,7 +461,7 @@ void DeleteClassifications(Barnyard2Config *bc)
     bc->classifications = NULL;
 }
 
-int ReadClassificationFile(Barnyard2Config *bc, const char *file)
+int ReadClassificationFile(Barnyard2Config *bc)
 {
     FILE        *fd;
     char        buf[BUFFER_SIZE];
@@ -470,25 +470,29 @@ int ReadClassificationFile(Barnyard2Config *bc, const char *file)
     int         num_toks;
     int         count = 0;
     
+    if( (bc == NULL) ||
+	(bc->class_file == NULL))
+    {
+	/* XXX */
+	return 1;
+    }
     
     DEBUG_WRAP(DebugMessage(DEBUG_MAPS, "map: opening file %s\n", file););
     
-    if((fd = fopen(file, "r")) == NULL)
+    if((fd = fopen(bc->class_file, "r")) == NULL)
     {
         LogMessage("ERROR: Unable to open Classification file '%s' (%s)\n", 
-                file, strerror(errno));
+		   bc->class_file, strerror(errno));
         
         return -1;
     }
     
-    bc->class_file =(char *)file;
-
     memset(buf, 0, BUFFER_SIZE); /* bzero() deprecated, replaced with memset() */
     
     while ( fgets(buf, BUFFER_SIZE, fd) != NULL )
     {
         index = buf;
-
+	
         /* advance through any whitespace at the beginning of the line */
         while (*index == ' ' || *index == '\t')
             index++;
@@ -511,8 +515,7 @@ int ReadClassificationFile(Barnyard2Config *bc, const char *file)
   if(fd != NULL)
     fclose(fd);
 
-  bc->class_file = NULL;
-
+  
   return 0;
 }
 
@@ -543,6 +546,7 @@ int SignatureResolveClassification(ClassType *class,SigNode *sig,char *sid_msg_f
     {
 	DEBUG_WRAP(DebugMessage(DEBUG_MAPS,"ERROR [%s()]: Failed class ptr [0x%x], sig ptr [0x%x], "
 				"sig_literal ptr [0x%x], sig_map_file ptr [0x%x], classification_file ptr [0x%x] \n",
+				__FUNCTION__,
 				class,
 				sig,
 				sig->classLiteral,

--- a/src/map.h
+++ b/src/map.h
@@ -132,7 +132,7 @@ ClassType * ClassTypeLookupByType(struct _Barnyard2Config *, char *);
 ClassType * ClassTypeLookupById(struct _Barnyard2Config *, int);
 
 int ReadReferenceFile(struct _Barnyard2Config *, const char *);
-int ReadClassificationFile(struct _Barnyard2Config *, const char *);
+int ReadClassificationFile(struct _Barnyard2Config *);
 int ReadSidFile(struct _Barnyard2Config *);
 int ReadGenFile(struct _Barnyard2Config *);
 int SignatureResolveClassification(ClassType *class,SigNode *sig,char *sid_map_file,char *classification_file);

--- a/src/output-plugins/spo_syslog_full.c
+++ b/src/output-plugins/spo_syslog_full.c
@@ -1284,14 +1284,18 @@ OpSyslog_Data *OpSyslog_ParseArgs(char *args)
         int i;
         /* parse out your args */
         toks = mSplit(args, ",", 31, &num_toks, '\\');
+
         for(i = 0; i < num_toks; ++i)
         {
             char **stoks;
             int num_stoks;
             char *index = toks[i];
-            while(isspace((int)*index))
+            
+	    while(isspace((int)*index))
                 ++index;
-            stoks = mSplit(index, " ", 2, &num_stoks, 0);
+	    
+	    stoks = mSplit(index, " ", 2, &num_stoks, 0);
+
             if(strcasecmp("port", stoks[0]) == 0)
             {
                 if(num_stoks > 1 )
@@ -1625,7 +1629,7 @@ OpSyslog_Data *OpSyslog_ParseArgs(char *args)
                         "SyslogFull plugin: %s\n", file_name, file_line, index);
             }	
 
-
+	    mSplitFree(&stoks,num_stoks);
 	}
 	/* free your mSplit tokens */
 	mSplitFree(&toks, num_toks);

--- a/src/parser.c
+++ b/src/parser.c
@@ -1702,7 +1702,9 @@ void ConfigClassificationFile(Barnyard2Config *bc, char *args)
     if ((args == NULL) || (bc == NULL) )
         return;
 
-    ReadClassificationFile(bc, args);
+    bc->class_file = strndup(args,strlen(args));
+
+    ReadClassificationFile(bc);
 }
 
 void ConfigCreatePidFile(Barnyard2Config *bc, char *args)


### PR DESCRIPTION
free of the classification file path name in ReadClassification().
     value is now copied properly and freed at cleanup.

Fix: leak in spo_syslog_full arguments parsing. (unrelated)

Needs retagging, re-versionning :)
