### PR TITLE
Fix a potential segfault in spo_syslog when p->iph == NULL

### DIFF
--- a/src/output-plugins/spo_syslog_full.c
+++ b/src/output-plugins/spo_syslog_full.c
@@ -1070,7 +1070,7 @@ void  OpSyslog_Alert(Packet *p, void *event, uint32_t event_type, void *arg)
 		}
 	    }
 	}
-	else
+	else if (IPH_IS_VALID(p))
 	{
 	    if(BcAlertInterface())
 	    {


### PR DESCRIPTION
Line 1033 tests IPH_IS_VALID(p), i.e. p != NULL. When this fails,
execution jumps to line 1073. Then on lines 1077 and 1093:

if(protocol_names[GET_IPH_PROTO(p)])

GET_IPH_PROTO(p) attempts to dereference p->iph: p->iph->ip_proto

However, it is possible that execution jumped here because p->iph was
NULL, so we need to test p->iph first.
