### PR TITLE
Add a way to set Prelude Analyzer name, model and manufacturer.

### DIFF
--- a/etc/barnyard2.conf
+++ b/etc/barnyard2.conf
@@ -233,8 +233,11 @@ output alert_fast: stdout
 # Purpose:
 #  This output module provides logging to the Prelude Hybrid IDS system
 #
-# Arguments: profile=snort-profile
-#   snort-profile   - name of the Prelude profile to use (default is snort).
+# Arguments:
+#   analyzer_name           - name of the Prelude analyzer (default is snort).
+#   analyzer_model          - model of the Prelude analyzer (default is Snort).
+#   analyzer_class          - class of the Prelude analyzer (default is NIDS).
+#   analyzer_manufacturer   - manufacturer of the Prelude anaylzer (default is http://www.snort.org).
 #
 # Snort priority to IDMEF severity mappings:
 # high < medium < low < info
@@ -247,8 +250,8 @@ output alert_fast: stdout
 #
 # Examples:
 #   output alert_prelude
-#   output alert_prelude: profile=snort-profile-name
-#
+#   output alert_prelude: analyzer_name=snort
+#   output alert_prelude: analyzer_name=sagan analyzer_model=sagan analyzer_class=Log\ Analyzer analyzer_manufacturer=http://sagan.quadrantsec.com
 
 
 # alert_syslog


### PR DESCRIPTION
Changes to allow prelude alerts to log not only with snort