### PR TITLE
spo_syslog_full bug fix and enhancement

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -2192,13 +2192,8 @@ void DecodeIPV6Options(int type, const uint8_t *pkt, uint32_t len, Packet *p)
 
     exthdr = (IP6Extension *)pkt;
 
-    /* BY2: we only track the first extension and don't do out of order
-    ** assessment as it's already been done by the engine that built it.
-    */
-    if (p->ip6_extension_count == 0) {
-      p->ip6_extensions[p->ip6_extension_count].type = type;
-      p->ip6_extensions[p->ip6_extension_count].data = pkt;
-    }
+    p->ip6_extensions[p->ip6_extension_count].type = type;
+    p->ip6_extensions[p->ip6_extension_count].data = pkt;
 
     // TBD add layers for other ip6 ext headers
     switch (type)

--- a/src/output-plugins/spo_syslog_full.c
+++ b/src/output-plugins/spo_syslog_full.c
@@ -306,8 +306,6 @@ int OpSyslog_LogConfig(void *pSyslogContext)
     iSyslogContext =(OpSyslog_Data *)pSyslogContext;
     
     LogMessage("spo_syslog_full config:\n");
-    LogMessage("\tDetail Level: %s\n",
-	       iSyslogContext->detail == 1 ? "Full" : "Fast");
     
     if(iSyslogContext->local_logging == 0)
     {
@@ -1336,17 +1334,6 @@ OpSyslog_Data *OpSyslog_ParseArgs(char *args)
                         op_data->proto = 0;
 		    else
 			op_data->proto = 1;
-                }
-                else 
-                    LogMessage("Argument Error in %s(%i): %s\n", file_name, 
-                            file_line, index);
-            }
-            else if(strcasecmp("detail", stoks[0]) == 0)
-            {
-                if(num_stoks > 1)
-                {
-                    if(strcasecmp("full", stoks[1]) == 0)
-                        op_data->detail = 1;
                 }
                 else 
                     LogMessage("Argument Error in %s(%i): %s\n", file_name, 

--- a/src/output-plugins/spo_syslog_full.c
+++ b/src/output-plugins/spo_syslog_full.c
@@ -1213,6 +1213,7 @@ void OpSyslog_Log(Packet *p, void *event, uint32_t event_type, void *arg)
     {
 	LogMessage("OpSyslog_Log(): Is currently unable to handle Event Type [%u] \n",
 		   event_type);
+        return;
     }
 
     syslogContext = (OpSyslog_Data *)arg;
@@ -1645,7 +1646,15 @@ OpSyslog_Data *OpSyslog_ParseArgs(char *args)
     /* Default */    
     if(op_data->sensor_name == NULL)
     {
-	FatalError("You must specify a sensor name\n");
+        // If barnyard2 config has hostname defined, use that
+        if (barnyard2_conf->hostname)
+        {
+            op_data->sensor_name = SnortStrdup(barnyard2_conf->hostname);
+        }
+        else
+        {
+            FatalError("You must specify a sensor name\n");
+        }
     }
 
     if(op_data->syslog_priority == 0)

--- a/src/output-plugins/spo_syslog_full.h
+++ b/src/output-plugins/spo_syslog_full.h
@@ -73,7 +73,6 @@ typedef struct _OpSyslog_Data
     
 
     u_int32_t port;
-    u_int16_t detail;
     u_int16_t proto;
 
     char delim;

--- a/src/spooler.c
+++ b/src/spooler.c
@@ -727,8 +727,6 @@ void spoolerProcessRecord(Spooler *spooler, int fire_output)
 
         /* allocate space for the packet and construct the packet header */
         spooler->record.pkt = SnortAlloc(sizeof(Packet));
-        spooler->record.pkt->ip6_extensions = SnortAlloc(sizeof(IP6Option) * 1);
-
 
         pkth.caplen = ntohl(((Unified2Packet *)spooler->record.data)->packet_length);
         pkth.len = pkth.caplen;
@@ -800,7 +798,6 @@ void spoolerProcessRecord(Spooler *spooler, int fire_output)
         }
 
         /* free the memory allocated in this function */
-        free(spooler->record.pkt->ip6_extensions);
         free(spooler->record.pkt);
         spooler->record.pkt = NULL;
 


### PR DESCRIPTION
spo_syslog_full.c
 - Add missing return after unsupported event type
 - If sensor_name is not defined but config has hostname defined, use barnyard hostname
 - Removed unused detail setting from arg parsing, struct, and config logging