### PR TITLE
This patch speeds up startup and adds the --unique-map option

### DIFF
--- a/etc/barnyard2.conf
+++ b/etc/barnyard2.conf
@@ -74,6 +74,10 @@ config sid_file:            /etc/snort/sid-msg.map
 #
 #config alert_with_interface_name
 
+#
+# speed up startup by feeding it unique maps
+#unique_map
+
 # at times snort will alert on a packet within a stream and dump that stream to
 # the unified output. barnyard2 can generate output on each packet of that
 # stream or the first packet only.

--- a/src/barnyard2.c
+++ b/src/barnyard2.c
@@ -184,6 +184,7 @@ static struct option long_options[] =
    {"event-cache-size", LONGOPT_ARG_REQUIRED, NULL, EVENT_CACHE_SIZE},
    {"alert-on-each-packet-in-stream", LONGOPT_ARG_NONE, NULL, ALERT_ON_EACH_PACKET_IN_STREAM},
    {"process-new-records-only", LONGOPT_ARG_NONE, NULL, 'n'},
+   {"unique-map", LONGOPT_ARG_NONE, NULL, UNIQUE_MAP},
 
 #ifdef MPLS
    {"max-mpls-labelchain-len", LONGOPT_ARG_REQUIRED, NULL, MAX_MPLS_LABELCHAIN_LEN},
@@ -519,6 +520,7 @@ static int ShowUsage(char *program_name)
 
     FPUTS_BOTH ("Longname options and their corresponding single char version\n");
     FPUTS_BOTH ("   --disable-alert-on-each-packet-in-stream  Alert once per event\n");
+    FPUTS_BOTH ("   --unique-map                      Don't check sid/gid maps for dupes (fast start)\n");
     FPUTS_BOTH ("   --event-cache-size <integer>      Set Spooler MAX event cache size \n");
     FPUTS_BOTH ("   --reference <file>                Same as -R\n");
     FPUTS_BOTH ("   --classification <file>           Same as -C\n");
@@ -682,6 +684,11 @@ static void ParseCmdLine(int argc, char **argv)
                 ConfigMplsPayloadType(bc, optarg);
                 break;
 #endif
+            case UNIQUE_MAP:
+                ConfigUniqueMap(bc, NULL);
+                break;
+
+
 
             case 'a':  /* use archive directory <x> */
                 ConfigArchiveDir(bc, optarg);
@@ -1811,6 +1818,8 @@ static Barnyard2Config * MergeBarnyard2Confs(Barnyard2Config *cmd_line, Barnyard
 	config_file->alert_on_each_packet_in_stream_flag = cmd_line->alert_on_each_packet_in_stream_flag;
     }
     
+    config_file->unique_map |= cmd_line->unique_map;
+
     config_file->process_new_records_only_flag = cmd_line->process_new_records_only_flag;
 
 #ifdef SUP_IP6

--- a/src/barnyard2.h
+++ b/src/barnyard2.h
@@ -185,7 +185,7 @@ typedef enum _GetOptLongIds
     MAX_MPLS_LABELCHAIN_LEN,
     MPLS_PAYLOAD_TYPE,
 #endif
-
+    UNIQUE_MAP,
     GET_OPT_LONG_IDS_MAX
 } GetOptLongIds;
 
@@ -327,6 +327,7 @@ typedef struct _Barnyard2Config
     int data_flag;
     int obfuscation_flag;
     int alert_on_each_packet_in_stream_flag;
+    int unique_map;
     
     int	logtosyslog_flag;
     int	test_mode_flag;
@@ -394,6 +395,7 @@ typedef struct _Barnyard2Config
     ClassType *classifications;
     ReferenceSystemNode *references;
     SigNode *sigHead;  /* Signature list Head */
+    SigNode *sigTail;  /* Signature list Tail */
     
     /* plugin active flags*/
     InputConfig *input_configs;
@@ -622,6 +624,11 @@ static INLINE int BcLogSyslog(void)
     return barnyard2_conf->logging_flags & LOGGING_FLAG__SYSLOG;
 }
 
+static INLINE int BcUniqueMap(void)
+{
+    return barnyard2_conf->unique_map;
+}
+
 static INLINE int BcAlertOnEachPacketInStream(void)
 {
     return barnyard2_conf->alert_on_each_packet_in_stream_flag;
@@ -762,6 +769,10 @@ static INLINE short BcSidMapVersion(void)
 static INLINE SigNode ** BcGetSigNodeHead(void)
 {
     return &barnyard2_conf->sigHead;
+}
+static INLINE SigNode ** BcGetSigNodeTail(void)
+{
+    return &barnyard2_conf->sigTail;
 }
 
 static INLINE Barnyard2Config * BcGetConfig(void)

--- a/src/map.c
+++ b/src/map.c
@@ -924,7 +924,7 @@ void ParseSidMapLine(Barnyard2Config *bc, char *data)
     
     /* Look if we have a brother inserted from sid map file */
     sig_lookup_continue:
-    if(SigLookup(sn,t_sn.generator,t_sn.id,SOURCE_SID_MSG,&sn))
+    if(!BcUniqueMap() && SigLookup(sn,t_sn.generator,t_sn.id,SOURCE_SID_MSG,&sn))
     {
 	if(t_sn.rev == sn->rev)
 	{
@@ -944,12 +944,11 @@ void ParseSidMapLine(Barnyard2Config *bc, char *data)
     }
     else
     {
-        if( (sn = CreateSigNode(BcGetSigNodeHead(),SOURCE_SID_MSG)) == NULL)
+        if( (sn = CreateSigNode(BcGetSigNodeHead(),BcGetSigNodeTail(),SOURCE_SID_MSG)) == NULL)
         {
             FatalError("[%s()], CreateSigNode() returned a NULL node, bailing \n",
                        __FUNCTION__);
         }
-
         memcpy(sn,&t_sn,sizeof(SigNode));
 
 	sn->source_file = SOURCE_SID_MSG;
@@ -1006,7 +1005,7 @@ SigNode *GetSigByGidSid(u_int32_t gid, u_int32_t sid,u_int32_t revision)
     }
     
     /* create a default message since we didn't find any match */
-    sn = CreateSigNode(BcGetSigNodeHead(),SOURCE_GEN_RUNTIME);
+    sn = CreateSigNode(BcGetSigNodeHead(),BcGetSigNodeTail(),SOURCE_GEN_RUNTIME);
     sn->generator = gid;
     sn->id = sid;
     sn->rev = revision;
@@ -1018,7 +1017,7 @@ SigNode *GetSigByGidSid(u_int32_t gid, u_int32_t sid,u_int32_t revision)
 
 
 
-SigNode *CreateSigNode(SigNode **head,const u_int8_t source_file)
+SigNode *CreateSigNode(SigNode **head,SigNode **tail,const u_int8_t source_file)
 {
     SigNode       *sn = NULL;
     
@@ -1027,18 +1026,16 @@ SigNode *CreateSigNode(SigNode **head,const u_int8_t source_file)
         *head = (SigNode *) SnortAlloc(sizeof(SigNode));
 	sn = *head;
 	sn->source_file = source_file;
+	*tail = *head;
         return *head;
     }
     else
     {
-        sn = *head;
-	
-        while (sn->next != NULL) 
-	    sn = sn->next;
-	
-        sn->next = (SigNode *) SnortAlloc(sizeof(SigNode));
-	sn->next->source_file = source_file;
-        return sn->next;
+	sn = (SigNode *) SnortAlloc(sizeof(SigNode));
+	sn->source_file = source_file;
+	(*tail)->next = sn;
+	*tail = sn;
+        return sn;
     }
     
     /* XXX */
@@ -1215,14 +1212,15 @@ void ParseGenMapLine(char *data)
     }
     else
     {
-	if(SigLookup((SigNode *)*BcGetSigNodeHead(),t_sn.generator,t_sn.id,SOURCE_GEN_MSG,&sn) == 0)
+	if(!BcUniqueMap() && SigLookup((SigNode *)*BcGetSigNodeHead(),t_sn.generator,t_sn.id,SOURCE_GEN_MSG,&sn) == 0)
 	{
-	    if( (sn = CreateSigNode(BcGetSigNodeHead(),SOURCE_GEN_MSG)) == NULL)
+printf("WTF: %d\n", !BcUniqueMap());
+	    if( (sn = CreateSigNode(BcGetSigNodeHead(),BcGetSigNodeTail(),SOURCE_GEN_MSG)) == NULL)
 	    {
 		FatalError("[%s()], CreateSigNode() returned a NULL node, bailing \n",
 			   __FUNCTION__);
 	    }
-	 
+
 	    memcpy(sn,&t_sn,sizeof(SigNode));
 	    
 	    sn->source_file = SOURCE_GEN_MSG;

--- a/src/map.h
+++ b/src/map.h
@@ -126,7 +126,7 @@ ReferenceSystemNode * ReferenceSystemLookup(ReferenceSystemNode *, char *);
 ReferenceNode * AddReference(struct _Barnyard2Config *, ReferenceNode **, char *, char *);
 
 SigNode *GetSigByGidSid(uint32_t, uint32_t, uint32_t);
-SigNode *CreateSigNode(SigNode **,u_int8_t);
+SigNode *CreateSigNode(SigNode **, SigNode **, u_int8_t);
 
 ClassType * ClassTypeLookupByType(struct _Barnyard2Config *, char *);
 ClassType * ClassTypeLookupById(struct _Barnyard2Config *, int);

--- a/src/output-plugins/spo_database_cache.c
+++ b/src/output-plugins/spo_database_cache.c
@@ -1068,7 +1068,7 @@ u_int32_t ConvertSignatureCache(SigNode **iHead,MasterCache *iMasterCache,Databa
 	}
 	
 	//Do not allow duplicate to exist
-	if( (cacheSignatureLookup(&lookupNode,iMasterCache->cacheSignatureHead) == 0) )
+	if( BcUniqueMap() || (cacheSignatureLookup(&lookupNode,iMasterCache->cacheSignatureHead) == 0) )
 	{
 	    if( (TobjNode = SnortAlloc(sizeof(cacheSignatureObj))) == NULL)
 	    {

--- a/src/parser.c
+++ b/src/parser.c
@@ -189,6 +189,7 @@ static const KeywordFunc barnyard2_conf_keywords[] =
 
 static const ConfigFunc config_opts[] =
 {
+    { CONFIG_OPT__UNIQUE_MAP, 0, 1, ConfigUniqueMap },
     { CONFIG_OPT__DISABLE_ALERT_ON_EACH_PACKET_IN_STREAM, 0, 1, ConfigDisableAlertOnEachPacketInStream },
     { CONFIG_OPT__EVENT_CACHE_SIZE, 0, 1, ConfigSetEventCacheSize },
     { CONFIG_OPT__ALERT_ON_EACH_PACKET_IN_STREAM, 0, 1, ConfigAlertOnEachPacketInStream },
@@ -1600,6 +1601,13 @@ void ConfigSetEventCacheSize(Barnyard2Config *bc, char *args)
     return;
 }
 
+void ConfigUniqueMap(Barnyard2Config *bc, char *args)
+{
+    if (bc == NULL)
+        return;
+
+    bc->unique_map = 1;
+}
 void ConfigDisableAlertOnEachPacketInStream(Barnyard2Config *bc, char *args)
 {
     if (bc == NULL)

--- a/src/parser.h
+++ b/src/parser.h
@@ -43,6 +43,7 @@
 #define BARNYARD2_CONF_KEYWORD__VERSION              "version"
 
 /* Config options */
+#define CONFIG_OPT__UNIQUE_MAP                     "unique_map"
 #define CONFIG_OPT__DISABLE_ALERT_ON_EACH_PACKET_IN_STREAM  "disable_alert_on_each_packet_in_stream"
 #define CONFIG_OPT__EVENT_CACHE_SIZE                "event_cache_size"
 #define CONFIG_OPT__ALERT_ON_EACH_PACKET_IN_STREAM  "alert_on_each_packet_in_stream"
@@ -110,6 +111,7 @@ void ConfigureOutputPlugins(Barnyard2Config *);
 NORETURN void ParseError(const char *, ...);
 void ParseMessage(const char *, ...);
 
+void ConfigUniqueMap(Barnyard2Config *, char *);
 void ConfigDisableAlertOnEachPacketInStream(Barnyard2Config *, char *);
 void ConfigAlertOnEachPacketInStream(Barnyard2Config *, char *);
 void ConfigAlertWithInterfaceName(Barnyard2Config *, char *);


### PR DESCRIPTION
Barnyard2 takes a very long time to start due to poorly
optimized list code.  For every SID added to the list, the entire
list is iterated to get to the tail of the list.  Adding and
maintaining a tail pointer prevents this, since we can just add
entries directly at the end.

The --unique-map option is also added, this prevents each SID from
the files being checked against what's in memory.  Most tools
generate unique files, making this check unnecessary and wasteful.