### PR TITLE
Missing dnet-devel dependency

### DIFF
--- a/rpm/barnyard2.spec
+++ b/rpm/barnyard2.spec
@@ -57,6 +57,7 @@ BuildRequires: libpcap1-devel
 %else
 BuildRequires: libpcap-devel
 %endif
+BuildRequires: libdnet-devel
 
 
 %description


### PR DESCRIPTION
Fixing missing dnet-devel dependency for creating RPMs