### PR TITLE
Changes to support command line option "-j" to include Event ID in alert output

### DIFF
--- a/README
+++ b/README
@@ -106,6 +106,7 @@ Command line:
         -h <name>  Define the hostname <name>. For logging purposes only
         -i <if>    Define the interface <if>. For logging purposes only
         -I         Add Interface name to alert output
+        -j         Add Event ID to alert output
         -l <ld>    Log to directory <ld>
         -m <umask> Set umask = <umask>
         -O         Obfuscate the logged IP addresses

--- a/src/barnyard2.c
+++ b/src/barnyard2.c
@@ -157,11 +157,11 @@ static char **barnyard2_argv = NULL;
 /* command line options for getopt */
 #ifndef WIN32
 /* Unix does not support an argument to -s <wink marty!> OR -E, -W */
-static char *valid_options = "?a:Ac:C:d:Def:Fg:G:h:i:Il:m:noOqr:R:S:t:Tu:UvVw:xXy";
+static char *valid_options = "?a:Ac:C:d:Def:Fg:G:h:i:Ijl:m:noOqr:R:S:t:Tu:UvVw:xXy";
 #else
 /* Win32 does not support:  -D, -g, -m, -t, -u */
 /* Win32 no longer supports an argument to -s, either! */
-static char *valid_options = "?a:Ac:C:d:eEf:FG:h:i:Il:noOqr:R:S:TUvVw:xXy";
+static char *valid_options = "?a:Ac:C:d:eEf:FG:h:i:Ijl:noOqr:R:S:TUvVw:xXy";
 #endif
 
 static struct option long_options[] =
@@ -487,6 +487,7 @@ static int ShowUsage(char *program_name)
     FPUTS_BOTH ("        -h <name>  Define the hostname <name>. For logging purposes only\n");
     FPUTS_BOTH ("        -i <if>    Define the interface <if>. For logging purposes only\n");
     FPUTS_BOTH ("        -I         Add Interface name to alert output\n");
+    FPUTS_BOTH ("        -j         Add Event ID to alert output\n");
     FPUTS_BOTH ("        -l <ld>    Log to directory <ld>\n");
     FPUTS_UNIX ("        -m <umask> Set umask = <umask>\n");
     FPUTS_BOTH ("        -O         Obfuscate the logged IP addresses\n");
@@ -748,6 +749,10 @@ static void ParseCmdLine(int argc, char **argv)
 
             case 'I':  /* add interface name to alert string */
                 ConfigAlertWithInterfaceName(bc, NULL);
+                break;
+
+            case 'j':
+                ConfigEventID(bc, NULL);
                 break;
 
             case 'l':  /* use log dir <X> */

--- a/src/barnyard2.h
+++ b/src/barnyard2.h
@@ -282,7 +282,8 @@ typedef enum _OutputFlag
     OUTPUT_FLAG__NO_TIMESTAMP      = 0x00000400,      /* --nostamps */
     OUTPUT_FLAG__ALERT_PKT_CNT     = 0x00000800,      /* -A packet-count */
     /* XXX XXX pv.outputVidInAlerts */
-    OUTPUT_FLAG__ALERT_VLAN        = 0x00001000       /* config include_vlan_in_alerts */
+    OUTPUT_FLAG__ALERT_VLAN        = 0x00001000,      /* config include_vlan_in_alerts */
+    OUTPUT_FLAG__ALERT_EVENTID     = 0x00002000       /* -j - include event id in alerts */
 
 } OutputFlag;
 
@@ -662,6 +663,11 @@ static INLINE int BcOutputIncludeYear(void)
 static INLINE int BcOutputUseUtc(void)
 {
     return barnyard2_conf->output_flags & OUTPUT_FLAG__USE_UTC;
+}
+
+static INLINE int BcOutputUseEventID(void)
+{
+    return barnyard2_conf->output_flags & OUTPUT_FLAG__ALERT_EVENTID;
 }
 
 static INLINE int BcOutputDataLink(void)

--- a/src/decode.c
+++ b/src/decode.c
@@ -638,7 +638,8 @@ void DecodeMPLS(const uint8_t* pkt, const uint32_t len, Packet* p)
     int iRet = 0;
 
     pc.mpls++;
-    UpdateMPLSStats(&sfBase, len, Active_PacketWasDropped());
+    // I believe this is a Snort function
+    // UpdateMPLSStats(&sfBase, len, Active_PacketWasDropped());
     tmpMplsHdr = (uint32_t *) pkt;
     p->mpls = NULL;
 

--- a/src/output-plugins/spo_alert_fast.c
+++ b/src/output-plugins/spo_alert_fast.c
@@ -181,6 +181,12 @@ static void AlertFast(Packet *p, void *event, uint32_t event_type, void *arg)
         TextLog_Puts(data->log, " [**] ");
 #endif
 
+        if(BcOutputUseEventID())
+        {
+            TextLog_Print(data->log, "(%lu) ",
+                (unsigned long) ntohl(((Unified2EventCommon *)event)->event_id));
+        }
+
         TextLog_Print(data->log, "[%lu:%lu:%lu] ",
                 (unsigned long) ntohl(((Unified2EventCommon *)event)->generator_id),
                 (unsigned long) ntohl(((Unified2EventCommon *)event)->signature_id),

--- a/src/output-plugins/spo_alert_full.c
+++ b/src/output-plugins/spo_alert_full.c
@@ -160,6 +160,12 @@ static void AlertFull(Packet *p, void *event, uint32_t event_type, void *arg)
 
         if(event != NULL)
         {
+                if(BcOutputUseEventID())
+                {
+                    TextLog_Print(data->log, "(%lu) ",
+                        (unsigned long) ntohl(((Unified2EventCommon *)event)->event_id));
+                }
+
                 TextLog_Print(data->log, "[%lu:%lu:%lu] ",
 						(unsigned long) ntohl(((Unified2EventCommon *)event)->generator_id),
 		                (unsigned long) ntohl(((Unified2EventCommon *)event)->signature_id),

--- a/src/output-plugins/spo_alert_syslog.c
+++ b/src/output-plugins/spo_alert_syslog.c
@@ -541,6 +541,16 @@ void AlertSyslog(Packet *p, void *event, uint32_t event_type, void *arg)
 
 //        if(event != NULL)
 //        {
+            if(BcOutputUseEventID())
+            {
+                if( SnortSnprintf(event_data, STD_BUF, "(%lu) ", 
+                              (unsigned long) ntohl(((Unified2EventCommon *)event)->event_id)) != SNORT_SNPRINTF_SUCCESS )
+                    return ;
+
+                if( strlcat(event_string, event_data, SYSLOG_BUF) >= SYSLOG_BUF )
+                    return ;
+            }
+
             if( SnortSnprintf(event_data, STD_BUF, "[%lu:%lu:%lu] ",
                               (unsigned long) ntohl(((Unified2EventCommon *)event)->generator_id),
                               (unsigned long) ntohl(((Unified2EventCommon *)event)->signature_id),

--- a/src/output-plugins/spo_alert_test.c
+++ b/src/output-plugins/spo_alert_test.c
@@ -169,6 +169,12 @@ void AlertTest(Packet *p, void *event, u_int32_t event_type, void *arg)
 
     if(event != NULL)
     {
+        if(BcOutputUseEventID())
+        {
+            fprintf(data->file, "(%lu)\t",
+                (unsigned long) ntohl(((Unified2EventCommon *)event)->event_id));
+        }
+
         fprintf(data->file, "%lu\t%lu\t%lu\t",
                 (unsigned long) ntohl(((Unified2EventCommon *)event)->generator_id),
                 (unsigned long) ntohl(((Unified2EventCommon *)event)->signature_id),

--- a/src/parser.c
+++ b/src/parser.c
@@ -2177,6 +2177,14 @@ void ConfigUtc(Barnyard2Config *bc, char *args)
     bc->output_flags |= OUTPUT_FLAG__USE_UTC;
 }
 
+void ConfigEventID(Barnyard2Config *bc, char *args)
+{
+    if (bc == NULL)
+        return;
+
+    bc->output_flags |= OUTPUT_FLAG__ALERT_EVENTID;
+}
+
 void ConfigVerbose(Barnyard2Config *bc, char *args)
 {
     if (bc == NULL)


### PR DESCRIPTION
The Event ID is often needed to tie the Snort/Suricata alert back to the actual data in the unified2 file.
