### PR TITLE
barnyard2 crashes sometime on large data

### DIFF
--- a/schemas/create_mysql
+++ b/schemas/create_mysql
@@ -147,7 +147,7 @@ CREATE TABLE opt    ( sid         INT      UNSIGNED NOT NULL,
 # Packet payload
 CREATE TABLE data   ( sid           INT      UNSIGNED NOT NULL,
                       cid           INT      UNSIGNED NOT NULL,
-                      data_payload  TEXT,
+                      data_payload  MEDIUMTEXT,
                       PRIMARY KEY (sid,cid));
 
 # encoding is a lookup table for storing encoding types


### PR DESCRIPTION
barnyard2 crashes sometime on large data

`FATAL ERROR: database mysql_error: Data too long for column 'data_payload'.`

Need to change type TEXT to MEDIUMTEXT