### PR TITLE
Correct the CEF output

### DIFF
--- a/src/output-plugins/spo_alert_cef.c
+++ b/src/output-plugins/spo_alert_cef.c
@@ -518,7 +518,7 @@ void AlertCEF(Packet *p, void *event, u_int32_t event_type, void *arg)
         return;
     }
 
-    SnortSnprintf(cef_message, SYSLOG_BUF, "CEF:0|snort|barnyard2|%s", VERSION);
+    SnortSnprintf(cef_message, SYSLOG_BUF, "CEF:0|snort|barnyard2|%s|", VERSION);
 
     if(p && IPH_IS_VALID(p))
     {


### PR DESCRIPTION
The `|` was missing between the version and the generator id. This causes arcsight to misread the fields.