### PR TITLE
Buffer size is too small for some lines in sig-msg.map

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -53,7 +53,7 @@
 #define URL_HEAD           "http://"
 #define NESSUS_URL_HEAD	   "http://cgi.nessus.org/plugins/dump.php3?id="
 
-#define BUFFER_SIZE  1024
+#define BUFFER_SIZE  2048
 
 
 #define SOURCE_SID_MSG     0x0001


### PR DESCRIPTION
some of the lines in sid-msg.map are longer than 1024 therefore barnyard2 fails to parse and simply quits.
Example.
3 || 48297 || 3 || attempted-admin || 0 || FILE-OTHER TRUFFLEHUNTER TALOS-2018-0705 attack attempt || cve,2018-4032 || cve,2018-4033 || cve,2018-4034 || cve,2018-4035 || cve,20
18-4036 || cve,2018-4037 || cve,2018-4041 || cve,2018-4042 || cve,2018-4043 || cve,2018-4044 || cve,2018-4045 || cve,2018-4046 || cve,2018-4047 || cve,2019-5011 || url,www.talo
sintelligence.com/reports/TALOS-2018-0705/ || url,www.talosintelligence.com/reports/TALOS-2018-0706/ || url,www.talosintelligence.com/reports/TALOS-2018-0707/ || url,www.talosi
ntelligence.com/reports/TALOS-2018-0708/ || url,www.talosintelligence.com/reports/TALOS-2018-0709/ || url,www.talosintelligence.com/reports/TALOS-2018-0710/ || url,www.talosint
elligence.com/reports/TALOS-2018-0715/ || url,www.talosintelligence.com/reports/TALOS-2018-0716/ || url,www.talosintelligence.com/reports/TALOS-2018-0717/ || url,www.talosintel
ligence.com/reports/TALOS-2018-0718/ || url,www.talosintelligence.com/reports/TALOS-2018-0719/ || url,www.talosintelligence.com/reports/TALOS-2018-0720/ || url,www.talosintelli
gence.com/reports/TALOS-2018-0721/ || url,www.talosintelligence.com/reports/TALOS-2019-0759/ 