### PR TITLE
fixes bug where pid path collides when running multiple barnyard2

### DIFF
--- a/rpm/barnyard2
+++ b/rpm/barnyard2
@@ -36,7 +36,10 @@ start() {
 		PIDFILE="/var/lock/subsys/barnyard2-$INT.pid"
 		ARCHIVEDIR="$SNORTDIR/$INT/archive"
 		WALDO_FILE="$SNORTDIR/$INT/barnyard2.waldo"
-		BARNYARD_OPTS="-D -c $CONF -d $SNORTDIR/${INT} -w $WALDO_FILE -l $SNORTDIR/${INT} -a $ARCHIVEDIR -f $LOG_FILE -X $PIDFILE $EXTRA_ARGS"
+		if [ ! -d /var/run/barnyard2-${INT} ]; then
+                        mkdir -p /var/run/barnyard2-${INT}
+                fi
+                BARNYARD_OPTS="-D -c $CONF -d $SNORTDIR/${INT} -w $WALDO_FILE -l $SNORTDIR/${INT} -a $ARCHIVEDIR -f $LOG_FILE -X $PIDFILE $EXTRA_ARGS --pid-path=/var/run/barnyard2-${INT}"
 		daemon $prog $BARNYARD_OPTS
 	done
 	RETVAL=$?


### PR DESCRIPTION
When barnyard2 is running with more than 1 snort, sysvinit and systemctl dont properly handle it.  Due to only being allowed to specify pid path and not pid name..  This work around creates a dir for each interface